### PR TITLE
画面外に要素が飛び出した時に外面幅が変わる問題の修正

### DIFF
--- a/src/pages/research/aviation/index.astro
+++ b/src/pages/research/aviation/index.astro
@@ -231,6 +231,7 @@ import Footer from '@components/footer.astro'
         height: 56.4vw;
         color: rgba(255, 255, 255, 0.6);
         white-space: nowrap;
+        overflow: hidden;
         font-family: 'Times New Roman', Times, serif;
         /* height: 1000px; */
       }
@@ -286,10 +287,7 @@ import Footer from '@components/footer.astro'
         flex-direction: row;
         align-items: center;
         justify-content: center;
-        padding: 20px; /* 任意のパディング設定 */
-
-        /* 以下、任意のスタイリング設定 */
-        /* background-color: #05a; */
+        padding: 20px;
       }
 
       .content-wrap .content-nameArea:after {


### PR DESCRIPTION
上部動画に表示しているキーワードが画面外に飛び出した時に画面外に要素分のページ幅が生成されてしまう問題を修正しました。
これでスマホ版で表示した時に画面がカクカク動きまくる問題が修正されたはず…？