### PR TITLE
Youtubeの埋め込み

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -377,6 +377,11 @@ const blog_posts = (
     </div>
   </section>
 
+  <!-- youtube 埋め込み -->
+  <div style="position: relative; width: 80vw; height: 45vw; margin: 0 auto;">
+    <iframe style="position: absolute; width: 100%; height: 100%;" src="https://www.youtube.com/embed/nue-bLFGKK8" allowfullscreen></iframe>
+  </div>
+  
   <!-- お問い合わせ -->
   <section class="mt-8">
     <LinkToForm />


### PR DESCRIPTION
トップページの下部にYoutubeを埋め込みました。
classでのstyle指定がよくわからなかったからstyleを直接指定してるけど、気になるようだったら書き換えてください。
普通にURLコピーするとhttps://youtu.be/⚪︎⚪︎⚪︎⚪︎⚪︎なんだけど
https://www.youtube.com/embed/⚪︎⚪︎⚪︎⚪︎⚪︎にしないと接続が拒否されるらしい。
埋め込みですよって言ってあげないとなんだね多分。
後一応youtubeの動画を保存してアップロードすると著作権ダメらしいけど、リンクをHTMLに埋め込むのは大丈夫らしい