### PR TITLE
edit blog list page detail

### DIFF
--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -7,43 +7,52 @@ export interface Props {
 }
 const { post } = Astro.props
 ---
-
-<div class="mb-6 p-4 sm:mb-0 md:w-1/3 md:px-4">
-  <div class="h-52 overflow-hidden rounded-lg">
-    <Image
-      alt="カバー画像"
-      class="h-full w-full object-cover object-center"
-      src={post.data.cover ?? defaultImage}
-    />
-  </div>
-  <div class="px-2">
-    <h2
-      class="title-font mt-2 h-16 overflow-hidden text-2xl font-medium text-gray-900"
-    >
-      {post.data.title}
-    </h2>
-    <p class="mt-2 h-12 overflow-hidden text-base leading-relaxed">
-      {post.data.lead}
-    </p>
-  </div>
-
-  <div class="mt-3 flex justify-end">
-    <a
-      class="inline-flex items-center text-lg text-indigo-500 hover:text-indigo-700 hover:underline"
-      href={`/blogs/${post.slug}/index.html`}
-    >
-      詳しく見る
-      <svg
-        fill="none"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        class="ml-2 h-4 w-4"
-        viewBox="0 0 24 24"
+<style is:inline>
+  @media (max-width: 600px) {
+    .card {
+      pointer-events: none; /* リンクを無効にする */
+      cursor: default; /* カーソルを通常の矢印に変更 */
+    }
+  }
+</style>
+<a href={`/blogs/${post.slug}/index.html`} class="card">
+  <div class="mb-6 p-4 sm:mb-0 md:w-1/3 md:px-4">
+    <div class="h-52 overflow-hidden rounded-lg">
+      <Image
+        alt="カバー画像"
+        class="h-full w-full object-cover object-center"
+        src={post.data.cover ?? defaultImage}
+      />
+    </div>
+    <div class="px-2">
+      <h2
+        class="title-font mt-2 h-16 overflow-hidden text-2xl font-medium text-gray-900"
       >
-        <path d="M5 12h14M12 5l7 7-7 7"></path>
-      </svg>
-    </a>
+        {post.data.title}
+      </h2>
+      <p class="mt-2 h-12 overflow-hidden text-base leading-relaxed">
+        {post.data.lead}
+      </p>
+    </div>
+  
+    <div class="mt-3 flex justify-end">
+      <a
+        class="inline-flex items-center text-lg text-indigo-500 hover:text-indigo-700 hover:underline"
+        href={`/blogs/${post.slug}/index.html`}
+      >
+        詳しく見る
+        <svg
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          class="ml-2 h-4 w-4"
+          viewBox="0 0 24 24"
+        >
+          <path d="M5 12h14M12 5l7 7-7 7"></path>
+        </svg>
+      </a>
+    </div>
   </div>
-</div>
+</a>


### PR DESCRIPTION
ブログ一覧のカードをクリックすることでブログページに遷移できるように修正しました。
スマホで表示した場合には遷移しません。