### PR TITLE
add border line to blogCard when hover

### DIFF
--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -16,7 +16,7 @@ const { post } = Astro.props
   }
 </style>
 <a href={`/blogs/${post.slug}/index.html`} class="card">
-  <div class="mb-6 p-4 sm:mb-0 md:w-1/3 md:px-4">
+  <div class="rounded-lg mb-6 p-4 sm:mb-0 md:w-1/3 md:px-4 hover:outline outline-blue-100">
     <div class="h-52 overflow-hidden rounded-lg">
       <Image
         alt="カバー画像"


### PR DESCRIPTION
ブログカードにカーソルが乗った時に、クリックして遷移できることが伝わるようにデザインを変更しました。