### PR TITLE
bug fix blogCard outline

### DIFF
--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -18,7 +18,7 @@ const { post } = Astro.props
 </style>
 <a href={`/blogs/${post.slug}/index.html`} class="card">
   <div
-    class="mb-6 w-full rounded-lg p-4 outline-blue-100 hover:outline sm:mb-0"
+    class="mb-6 w-full rounded-lg p-4 outline-blue-100 md:hover:outline sm:mb-0"
   >
     <div class="h-52 w-full rounded-lg">
       <Image


### PR DESCRIPTION
スマホでカードをタップしても遷移はしないのに、アウトラインは表示されてしまう問題を修正しました。