### PR TITLE
Corrected the Author Card link to a relative link.

### DIFF
--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -10,7 +10,7 @@ const { author } = Astro.props
 
 <div class="max-w-xs">
 <a
-  href={`https://www.takahashi.qse.tohoku.ac.jp/member/${author?.slug}/index.html`}
+  href={`/member/${author?.slug}/index.html`}
 >
   <div class="border border-gray-600 py-8 text-center">
     <div


### PR DESCRIPTION
ブログに表示されるAuthor Cardのリンクが絶対リンクとなっていたのを相対リンクに書き換えました。